### PR TITLE
Draft: restrict mailman to university networks

### DIFF
--- a/modules/mailman.nix
+++ b/modules/mailman.nix
@@ -31,5 +31,13 @@
   services.nginx.virtualHosts."lists.${config.fsr.domain}" = {
     enableACME = true;
     forceSSL = true;
+    # deny non-uni access to prevent sending dozens of confirm emails
+    locations."/mailman3".extraConfig = ''
+      allow 141.30.0.0/16;
+      allow 141.76.0.0/16;
+      allow 172.16.0.0/16;
+      deny all;
+      uwsgi_pass unix:/run/mailman-web.socket;
+    '';
   };
 }


### PR DESCRIPTION
Current lists get bottet a lot and we are sending useless confirmation emails. Possibly bringing down our reputation at other providers.
Restricting registration to university networks helps on this.