### PR TITLE
nextcloud: configure ldap automatically via nextcloud-occ cli

### DIFF
--- a/modules/nextcloud.nix
+++ b/modules/nextcloud.nix
@@ -14,7 +14,7 @@ in
   services = {
     nextcloud = {
       enable = true;
-      package = pkgs.nextcloud26; # Use current latest nextcloud package
+      package = pkgs.nextcloud25;
       enableBrokenCiphersForSSE = false; # disable the openssl warning
       hostName = domain;
       https = true; # Use https for all urls
@@ -26,6 +26,7 @@ in
         adminpassFile = config.sops.secrets.nextcloud_adminpass.path;
         adminuser = "root";
       };
+      # postgres database is configured automatically
       database.createLocally = true;
     };
 


### PR DESCRIPTION
LDAP is now being enabled and configured automatically before the phpfpm-nextcloud service starts. Also, all groups from LDAP get synced, might be useful for e.g. sharing folders only with specific working groups, etc.

(The service startup is noticably slower because of this change, I'll see if that can be improved.)

Tested on my test vps, will merge and deploy on quitte if everything looks ok.