### PR TITLE
portunus: add patch to fix non-ascii character bug

### DIFF
--- a/modules/ldap/0003-gecos-ascii-escape.patch
+++ b/modules/ldap/0003-gecos-ascii-escape.patch
@@ -1,0 +1,24 @@
+diff --git a/internal/core/user.go b/internal/core/user.go
+index e74ccfe..291c75b 100644
+--- a/internal/core/user.go
++++ b/internal/core/user.go
+@@ -8,6 +8,7 @@ package core
+ 
+ import (
+ 	"fmt"
++	"strconv"
+ )
+ 
+ // User represents a single user account.
+@@ -86,9 +87,9 @@ func (u User) RenderToLDAP(suffix string, allGroups map[string]Group) LDAPObject
+ 			obj.Attributes["loginShell"] = []string{u.POSIX.LoginShell}
+ 		}
+ 		if u.POSIX.GECOS == "" {
+-			obj.Attributes["gecos"] = []string{u.FullName()}
++			obj.Attributes["gecos"] = []string{strconv.QuoteToASCII(u.FullName())}
+ 		} else {
+-			obj.Attributes["gecos"] = []string{u.POSIX.GECOS}
++			obj.Attributes["gecos"] = []string{strconv.QuoteToASCII(u.POSIX.GECOS)}
+ 		}
+ 		obj.Attributes["objectClass"] = append(obj.Attributes["objectClass"], "posixAccount")
+ 	}

--- a/modules/ldap/default.nix
+++ b/modules/ldap/default.nix
@@ -59,6 +59,7 @@ in
       patches = [
         ./0001-update-user-validation-regex.patch
         ./0002-both-ldap-and-ldaps.patch
+        ./0003-gecos-ascii-escape.patch
       ];
     });
 


### PR DESCRIPTION
The ldap gecos field is an IA5String (only supports ascii characters), so an error is thrown when Portunus tries to put the unescaped full name of a user in there, if it contains e.g. an umlaut.

This fix escapes the gecos field, e.g. "Müller" becomes "M\u00fcller" - not pretty, but I don't think this field is used for anything important anyway.

The name fields themselves support unicode just fine.