### PR TITLE
mail: update smtp_helo_hostname to match rDNS

### DIFF
--- a/hosts/quitte/network.nix
+++ b/hosts/quitte/network.nix
@@ -11,6 +11,7 @@ in
 
   networking = {
     hostId = "a71c81fc";
+    rdns = "x8d1e1ea9.agdsn.tu-dresden.de";
     enableIPv6 = true;
     useDHCP = true;
     interfaces.ens18.useDHCP = true;

--- a/modules/mail.nix
+++ b/modules/mail.nix
@@ -72,7 +72,8 @@ in
       config = {
         home_mailbox = "Maildir/";
         # hostname used in helo command. It is recommended to have this match the reverse dns entry
-        smtp_helo_name = "x8d1e1ea9.agdsn.tu-dresden.de";
+        # smtp_helo_name = "x8d1e1ea9.agdsn.tu-dresden.de";
+        smtp_helo_name = config.networking.rdns;
         smtp_use_tls = true;
         # smtp_tls_security_level = "encrypt";
         smtpd_use_tls = true;

--- a/modules/options.nix
+++ b/modules/options.nix
@@ -11,4 +11,9 @@
       description = "under which top level domain the services should run";
     };
   };
+  options.networking.rdns = mkOption {
+    type = types.str;
+    default = networking.fqdn;
+    description = "The reverse dns record known to be set for this host.";
+  };
 }


### PR DESCRIPTION
The smtp_helo_hostname should match the rDNS of the ip sending.