### PR TITLE
Allow users to use the server as remote builder

### DIFF
--- a/hosts/quitte/configuration.nix
+++ b/hosts/quitte/configuration.nix
@@ -17,6 +17,12 @@
 
   services.qemuGuest.enable = true;
 
+  # don't freeze the whole system while building something
+  nix.settings.cores = 16;
+
+  # allows everyone in the nix-trusted group to perform builds
+  nix.settings.trusted-users = [ "@nix-trusted" ];
+
   # Set your time zone.
   time.timeZone = "Europe/Berlin";
 


### PR DESCRIPTION
## Proposal
Allow users who ask for it to use the server as a remote builder for their nix projects.
FSR Infrastructure has a history of being used for private belongings too and there haven't been problems with it. A lot in here follows the fair use principle.

## Implementation
Trusted users are managed via an ldap group. And can then use the nix daemon as their local ldap user.
