### PR TITLE
tomate: init sssd

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -81,9 +81,10 @@
             ./modules/base.nix
             ./modules/zsh.nix
             ./modules/fail2ban.nix
-            # {
-            #   sops.defaultSopsFile = ./secrets/tomate.yaml;
-            # }
+            ./modules/sssd.nix
+            {
+              sops.defaultSopsFile = ./secrets/tomate.yaml;
+            }
           ];
         };
       };

--- a/hosts/tomate/configuration.nix
+++ b/hosts/tomate/configuration.nix
@@ -101,18 +101,6 @@
   # Enable touchpad support (enabled default in most desktopManager).
   # services.xserver.libinput.enable = true;
 
-  # Define a user account. Don't forget to set a password with ‘passwd’.
-  users.users.fsr = {
-    isNormalUser = true;
-    description = "FSR Informatik";
-    extraGroups = [ "networkmanager" ];
-    packages = with pkgs; [
-      firefox
-      kate
-      #  thunderbird
-    ];
-  };
-
   # Allow unfree packages
   nixpkgs.config.allowUnfree = true;
 

--- a/modules/sssd.nix
+++ b/modules/sssd.nix
@@ -1,0 +1,38 @@
+{ config, ...}:
+{
+  sops.secrets = {
+    "sssd/env"= {};
+
+  };
+  services.sssd = {
+    enable = true;
+    environmentFile = config.sops.secrets."sssd/env".path;
+    sshAuthorizedKeysIntegration = true;
+    config = ''
+      [sssd]
+      config_file_version = 2
+      services = nss, pam, ssh
+      domains = ldap
+
+      [ssh]
+
+      [nss]
+
+      [pam]
+
+      [domain/ldap]
+      auth_provider = ldap
+      ldap_uri = ldaps://auth.ifsr.de
+      ldap_default_authtok_type = password
+      ldap_default_authtok = $SSSD_LDAP_DEFAULT_AUTHTOK
+      ldap_search_base = dc=ifsr,dc=de
+      id_provider = ldap
+      ldap_default_bind_dn = uid=search,ou=users,dc=ifsr,dc=de
+      cache_credentials = True
+      ldap_tls_cacert = /etc/ssl/certs/ca-bundle.crt
+      ldap_tls_reqcert = hard
+    '';
+    
+  };
+  security.pam.services.sshd.makeHomeDir = true;
+}

--- a/modules/sssd.nix
+++ b/modules/sssd.nix
@@ -1,7 +1,7 @@
-{ config, ...}:
+{ config, ... }:
 {
   sops.secrets = {
-    "sssd/env"= {};
+    "sssd/env" = { };
 
   };
   services.sssd = {
@@ -32,7 +32,7 @@
       ldap_tls_cacert = /etc/ssl/certs/ca-bundle.crt
       ldap_tls_reqcert = hard
     '';
-    
+
   };
   security.pam.services.sshd.makeHomeDir = true;
 }

--- a/modules/sssd.nix
+++ b/modules/sssd.nix
@@ -34,5 +34,8 @@
     '';
 
   };
-  security.pam.services.sshd.makeHomeDir = true;
+  security.pam.services = {
+    sshd.makeHomeDir = true;
+    login.makeHomeDir = true;
+  };
 }


### PR DESCRIPTION
configures sssd for ldap login
- replaces everything under the `users.ldap` option and nslcd

Advantages of sssd:
- automatic fetching of ssh keys from ldap
- support for eventual auth extension like kerberos if we ever plan to implement it