### PR TITLE
quitte: enable ssh in initrd

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -69,6 +69,7 @@
             ./modules/manual.nix
             ./modules/sharepic.nix
             ./modules/zammad.nix
+            ./modules/initrd-ssh.nix
             {
               nixpkgs.overlays = [ self.overlays.default ];
               sops.defaultSopsFile = ./secrets/quitte.yaml;

--- a/modules/initrd-ssh.nix
+++ b/modules/initrd-ssh.nix
@@ -1,0 +1,19 @@
+# Find the required kernel module for the network adapter using `lspci -v` and add it to `boot.initrd.availableKernelModules`.
+# Enable `networking.useDHCP` or set a static ip using the `ip=` kernel parameter.
+# Generate another SSH host key for the machine:
+# $ ssh-keygen -t ed25519 -N "" -f /etc/ssh/ssh_host_ed25519_key_initrd -C HOSTNAME-initrd
+# Add the public key to your known_hosts and create an ssh config entry.
+{ ... }:
+{
+  boot.initrd.network = {
+    enable = true;
+    ssh = {
+      enable = true;
+      port = 222;
+      shell = "/bin/cryptsetup-askpass";
+      hostKeys = [ "/etc/ssh/ssh_host_ed25519_key_initrd" ];
+      # authorizedKeys option inherits root's authorizedKeys.keys, but not keyFiles
+    };
+  };
+}
+


### PR DESCRIPTION
Another host key needs to be generated, see `modules/initrd-ssh.nix`.

> Unless your bootloader supports initrd secrets, these keys are stored insecurely in the global Nix store. Do NOT use your regular SSH host private keys for this purpose or you'll expose them to regular users!
> 
> Additionally, even if your initrd supports secrets, if you're using initrd SSH to unlock an encrypted disk then using your regular host keys exposes the private keys on your unencrypted boot partition.

Since we use systemd-boot, we're fine.