### PR TITLE
Portunus 2.0 from nixos-unstable

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -190,6 +190,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1709479366,
+        "narHash": "sha256-n6F0n8UV6lnTZbYPl1A9q1BS0p4hduAv1mGAP17CVd0=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "b8697e57f10292a6165a20f03d2f42920dfaf973",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1682134069,
@@ -256,6 +272,7 @@
         "kpp": "kpp",
         "nix-index-database": "nix-index-database",
         "nixpkgs": "nixpkgs",
+        "nixpkgs-unstable": "nixpkgs-unstable",
         "print-interface": "print-interface",
         "sops-nix": "sops-nix",
         "vscode-server": "vscode-server"

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,7 @@
 {
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-23.11";
+    nixpkgs-unstable.url = "github:nixos/nixpkgs/nixos-unstable";
     sops-nix.url = "github:Mic92/sops-nix";
     sops-nix.inputs.nixpkgs.follows = "nixpkgs";
     nix-index-database.url = "github:nix-community/nix-index-database";
@@ -59,9 +60,9 @@
       });
       overlays.default = import ./overlays;
       nixosConfigurations = {
-        quitte = nixpkgs.lib.nixosSystem {
+        quitte = nixpkgs.lib.nixosSystem rec {
           system = "x86_64-linux";
-          specialArgs = inputs;
+          specialArgs = inputs // { inherit system; };
           modules = [
             inputs.sops-nix.nixosModules.sops
             inputs.kpp.nixosModules.default

--- a/modules/ldap/0001-update-user-validation-regex.patch
+++ b/modules/ldap/0001-update-user-validation-regex.patch
@@ -1,25 +1,35 @@
-From f5c68898be345fb0dca5ab7b596b9cbe674f5dfb Mon Sep 17 00:00:00 2001
-From: Rouven Seifert <rouven@rfive.de>
-Date: Tue, 4 Jul 2023 15:14:00 +0200
-Subject: [PATCH] update user validation regex
-
----
- internal/core/validation.go | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
-
-diff --git a/internal/core/validation.go b/internal/core/validation.go
-index 3e168b5..10dfc0a 100644
---- a/internal/core/validation.go
-+++ b/internal/core/validation.go
-@@ -30,7 +30,7 @@ import (
- )
- 
- //this regexp copied from useradd(8) manpage
--const posixAccountNamePattern = `[a-z_][a-z0-9_-]*\$?`
-+const posixAccountNamePattern = `[a-z_][a-z0-9._-]*\$?`
+diff --git a/cmd/portunus-orchestrator/config.go b/cmd/portunus-orchestrator/config.go
+index 4db19f2..290128a 100644
+--- a/cmd/portunus-orchestrator/config.go
++++ b/cmd/portunus-orchestrator/config.go
+@@ -23,7 +23,7 @@ type valueCheck struct {
+ }
  
  var (
- 	errIsMissing      = errors.New("is missing")
--- 
-2.41.0
-
+-	userOrGroupPattern = `^[a-z_][a-z0-9_-]*\$?$`
++	userOrGroupPattern = `^[a-z_][a-z0-9._-]*\$?$`
+ 	envDefaults        = map[string]string{
+ 		//empty value = not optional
+ 		"PORTUNUS_DEBUG":              "false",
+diff --git a/internal/grammars/grammars.go b/internal/grammars/grammars.go
+index 1253c05..e458fd0 100644
+--- a/internal/grammars/grammars.go
++++ b/internal/grammars/grammars.go
+@@ -39,7 +39,7 @@ const (
+ 	// This regex is based on the respective format description in the useradd(8) manpage.
+ 	//
+ 	// This is only shown for documentation purposes here; use func IsPOSIXAccountName instead.
+-	POSIXAccountNameRegex = `^[a-z_][a-z0-9_-]*\$?$`
++	POSIXAccountNameRegex = `^[a-z_][a-z0-9._-]*\$?$`
+ )
+ 
+ //TODO There is also some `import "regexp"` in cmd/orchestrator/ldap.go to render
+@@ -159,7 +159,7 @@ func checkByteInPOSIXAccountName(idx, length int, b byte) bool {
+ 	switch {
+ 	case (b >= 'a' && b <= 'z') || b == '_':
+ 		return true
+-	case (b >= '0' && b <= '9') || b == '-':
++	case (b >= '0' && b <= '9') || b == '-' || b == '.':
+ 		return idx != 0 // not allowed at start
+ 	default:
+ 		return false

--- a/modules/ldap/0002-both-ldap-and-ldaps.patch
+++ b/modules/ldap/0002-both-ldap-and-ldaps.patch
@@ -1,8 +1,8 @@
-diff --git a/cmd/orchestrator/ldap.go b/cmd/orchestrator/ldap.go
-index ed0d466..a672046 100644
---- a/cmd/orchestrator/ldap.go
-+++ b/cmd/orchestrator/ldap.go
-@@ -130,7 +130,7 @@ func runLDAPServer(environment map[string]string) {
+diff --git a/cmd/portunus-orchestrator/ldap.go b/cmd/portunus-orchestrator/ldap.go
+index 9564c5e..40cd2d7 100644
+--- a/cmd/portunus-orchestrator/ldap.go
++++ b/cmd/portunus-orchestrator/ldap.go
+@@ -134,7 +134,7 @@ func runLDAPServer(environment map[string]string) {
  
  	bindURL := "ldap:///"
  	if environment["PORTUNUS_SLAPD_TLS_CERTIFICATE"] != "" {

--- a/modules/ldap/0003-gecos-ascii-escape.patch
+++ b/modules/ldap/0003-gecos-ascii-escape.patch
@@ -1,24 +1,26 @@
-diff --git a/internal/core/user.go b/internal/core/user.go
-index e74ccfe..291c75b 100644
---- a/internal/core/user.go
-+++ b/internal/core/user.go
-@@ -8,6 +8,7 @@ package core
+diff --git a/internal/ldap/object.go b/internal/ldap/object.go
+index d4e5c6f..fcefec7 100644
+--- a/internal/ldap/object.go
++++ b/internal/ldap/object.go
+@@ -8,6 +8,7 @@ package ldap
  
  import (
  	"fmt"
-+	"strconv"
- )
++	"regexp"
  
- // User represents a single user account.
-@@ -86,9 +87,9 @@ func (u User) RenderToLDAP(suffix string, allGroups map[string]Group) LDAPObject
+ 	"github.com/majewsky/portunus/internal/core"
+ )
+@@ -94,10 +95,11 @@ func renderUser(u core.User, dnSuffix string, allGroups []core.Group) Object {
+ 		if u.POSIX.LoginShell != "" {
  			obj.Attributes["loginShell"] = []string{u.POSIX.LoginShell}
  		}
++		var nonASCII = regexp.MustCompile("[^\\x00-\\x7F]")
  		if u.POSIX.GECOS == "" {
 -			obj.Attributes["gecos"] = []string{u.FullName()}
-+			obj.Attributes["gecos"] = []string{strconv.QuoteToASCII(u.FullName())}
++			obj.Attributes["gecos"] = []string{nonASCII.ReplaceAllString(u.FullName(), "")}
  		} else {
 -			obj.Attributes["gecos"] = []string{u.POSIX.GECOS}
-+			obj.Attributes["gecos"] = []string{strconv.QuoteToASCII(u.POSIX.GECOS)}
++			obj.Attributes["gecos"] = []string{nonASCII.ReplaceAllString(u.POSIX.GECOS, "")}
  		}
  		obj.Attributes["objectClass"] = append(obj.Attributes["objectClass"], "posixAccount")
  	}

--- a/modules/ldap/0004-make-givenName-optional.patch
+++ b/modules/ldap/0004-make-givenName-optional.patch
@@ -1,8 +1,20 @@
 diff --git a/internal/core/user.go b/internal/core/user.go
-index e74ccfe..ce03eeb 100644
+index f45fdf7..4f93b37 100644
 --- a/internal/core/user.go
 +++ b/internal/core/user.go
-@@ -64,7 +64,6 @@ func (u User) RenderToLDAP(suffix string, allGroups map[string]Group) LDAPObject
+@@ -76,7 +76,6 @@ func (u User) validateLocal(cfg *ValidationConfig) (errs errext.ErrorSet) {
+ 		MustBePosixAccountNameIf(u.LoginName, u.POSIX != nil),
+ 	))
+ 	errs.Add(ref.Field("given_name").WrapFirst(
+-		MustNotBeEmpty(u.GivenName),
+ 		MustNotHaveSurroundingSpaces(u.GivenName),
+ 	))
+ 	errs.Add(ref.Field("family_name").WrapFirst(
+diff --git a/internal/ldap/object.go b/internal/ldap/object.go
+index d4e5c6f..1225084 100644
+--- a/internal/ldap/object.go
++++ b/internal/ldap/object.go
+@@ -73,7 +73,6 @@ func renderUser(u core.User, dnSuffix string, allGroups []core.Group) Object {
  			"uid":          {u.LoginName},
  			"cn":           {u.FullName()},
  			"sn":           {u.FamilyName},
@@ -10,7 +22,7 @@ index e74ccfe..ce03eeb 100644
  			"userPassword": {u.PasswordHash},
  			"isMemberOf":   memberOfGroupDNames,
  			"objectClass":  {"portunusPerson", "inetOrgPerson", "organizationalPerson", "person", "top"},
-@@ -74,6 +73,9 @@ func (u User) RenderToLDAP(suffix string, allGroups map[string]Group) LDAPObject
+@@ -83,6 +82,9 @@ func renderUser(u core.User, dnSuffix string, allGroups []core.Group) Object {
  	if u.EMailAddress != "" {
  		obj.Attributes["mail"] = []string{u.EMailAddress}
  	}
@@ -20,15 +32,3 @@ index e74ccfe..ce03eeb 100644
  	if len(u.SSHPublicKeys) > 0 {
  		obj.Attributes["sshPublicKey"] = u.SSHPublicKeys
  	}
-diff --git a/internal/frontend/users.go b/internal/frontend/users.go
-index 225c5b3..1a961ca 100644
---- a/internal/frontend/users.go
-+++ b/internal/frontend/users.go
-@@ -168,7 +168,6 @@ func buildUserMasterdataFieldset(e core.Engine, u *core.User, state *h.FormState
- 			Name:      "given_name",
- 			Label:     "Given name",
- 			Rules: []h.ValidationRule{
--				core.MustNotBeEmpty,
- 				core.MustNotHaveSurroundingSpaces,
- 			},
- 		},


### PR DESCRIPTION
Main improvement in Portunus 2.0 is support for better password hashes and automatically upgrading them upon login.

Our patches had to be rebased. Changing the posix account name regex has become more annoying, unfortunately. It's hardcoded in multiple places now, including unit tests, which I opted to disable instead of patching everything.