### PR TITLE
core: configure log retention

### DIFF
--- a/modules/core/default.nix
+++ b/modules/core/default.nix
@@ -2,6 +2,7 @@
 {
   imports = [
     ./base.nix
+    ./logging.nix
     ./bacula.nix
     ./fail2ban.nix
     ./initrd-ssh.nix

--- a/modules/core/logging.nix
+++ b/modules/core/logging.nix
@@ -1,0 +1,36 @@
+{ pkgs, ... }:
+{
+  services.rsyslogd = {
+    enable = true;
+    defaultConfig = ''
+      :programname, isequal, "postfix" /var/log/postfix.log
+
+      auth.*                          -/var/log/auth.log
+    '';
+  };
+  services.logrotate.configFile = pkgs.writeText "logrotate.conf" ''
+    weekly
+    missingok
+    notifempty
+    rotate 4
+    "/var/log/postfix.log" {
+      compress
+      delaycompress
+      weekly
+      rotate 156
+      dateext
+      dateformat .%Y-%m-%d
+      extension log
+    }
+    "/var/log/nginx/*.log" {
+      compress
+      delaycompress
+      weekly
+      postrotate
+        [ ! -f /var/run/nginx/nginx.pid ] || kill -USR1 `cat /var/run/nginx/nginx.pid`
+      endscript
+      rotate 26
+      su nginx nginx
+    }
+  '';
+}


### PR DESCRIPTION
Exports logs from the journal to plaintext files and rotates them

### Currently Configured
- Postfix logs: Keep for 3 years
- Auth logs: Keep for 3 years
