### PR TITLE
nginx: streamline all `forceSSL` and `enableACME` directives in one file

### DIFF
--- a/modules/core/nginx.nix
+++ b/modules/core/nginx.nix
@@ -5,6 +5,8 @@
     services.nginx.virtualHosts = mkOption {
       type = types.attrsOf (types.submodule
         ({ name, ... }: {
+          enableACME = true;
+          forceSSL = true;
           # split up nginx access logs per vhost
           extraConfig = ''
             access_log /var/log/nginx/${name}_access.log;

--- a/modules/courses/default.nix
+++ b/modules/courses/default.nix
@@ -45,9 +45,6 @@ in
   };
 
   services.nginx.virtualHosts.${hostName} = {
-    enableACME = true;
-    forceSSL = true;
-
     # phil redirects
     locations =
       let

--- a/modules/decisions.nix
+++ b/modules/decisions.nix
@@ -19,8 +19,6 @@ in
 
   services.nginx = {
     virtualHosts."${domain}" = {
-      enableACME = true;
-      forceSSL = true;
       locations."/" = {
         proxyPass = "http://127.0.0.1:5055";
       };

--- a/modules/gitea.nix
+++ b/modules/gitea.nix
@@ -109,8 +109,6 @@ in
     '';
 
   services.nginx.virtualHosts.${domain} = {
-    enableACME = true;
-    forceSSL = true;
     locations."/" = {
       proxyPass = "http://unix:${config.services.forgejo.settings.server.HTTP_ADDR}:/";
       proxyWebsockets = true;

--- a/modules/hedgedoc.nix
+++ b/modules/hedgedoc.nix
@@ -68,8 +68,6 @@ in
       recommendedProxySettings = true;
       virtualHosts = {
         "${domain}" = {
-          enableACME = true;
-          forceSSL = true;
           locations."/" = {
             proxyPass = "http://[::1]:${toString config.services.hedgedoc.settings.port}";
             proxyWebsockets = true;

--- a/modules/hydra.nix
+++ b/modules/hydra.nix
@@ -60,8 +60,6 @@ in
 
   };
   services.nginx.virtualHosts."${domain}" = {
-    enableACME = true;
-    forceSSL = true;
     locations."/" = {
       proxyPass = "http://127.0.0.1:${toString config.services.hydra.port}";
     };

--- a/modules/kanboard.nix
+++ b/modules/kanboard.nix
@@ -35,14 +35,10 @@ in
   services.nginx.enable = true;
   services.nginx = {
     virtualHosts."${domain_short}" = {
-      enableACME = true;
-      forceSSL = true;
       locations."/".return = "301 $scheme://${domain}$request_uri";
     };
 
     virtualHosts."${domain}" = {
-      addSSL = true;
-      enableACME = true;
       root = "/srv/web/kanboard";
       extraConfig = ''
         index index.html index.php;

--- a/modules/ldap/default.nix
+++ b/modules/ldap/default.nix
@@ -113,8 +113,6 @@ in
   services.nginx = {
     enable = true;
     virtualHosts."${config.services.portunus.domain}" = {
-      forceSSL = true;
-      enableACME = true;
       locations = {
         "/".proxyPass = "http://localhost:${toString config.services.portunus.port}";
         "/dex".proxyPass = "http://localhost:${toString config.services.portunus.dex.port}";

--- a/modules/mail/default.nix
+++ b/modules/mail/default.nix
@@ -11,11 +11,6 @@ in
     ./mailman.nix
   ];
 
-  # Get SSL certs for dovecot and postfix via ngnix
-  services.nginx.virtualHosts."${hostname}" = {
-    forceSSL = true;
-    enableACME = true;
-  };
   security.acme.certs."${hostname}" = {
     reloadServices = [
       "postfix.service"

--- a/modules/mail/mailman.nix
+++ b/modules/mail/mailman.nix
@@ -64,8 +64,6 @@
     ensureDatabases = [ "mailman" "mailman-web" ];
   };
   services.nginx.virtualHosts."lists.${config.networking.domain}" = {
-    enableACME = true;
-    forceSSL = true;
     locations."/robots.txt" = {
       extraConfig = ''
         add_header  Content-Type  text/plain;

--- a/modules/mail/rspamd.nix
+++ b/modules/mail/rspamd.nix
@@ -117,8 +117,6 @@ in
     };
     nginx = {
       virtualHosts."${domain}" = {
-        forceSSL = true;
-        enableACME = true;
         locations = {
           "/" = {
             proxyPass = "http://127.0.0.1:11334";

--- a/modules/mail/sogo.nix
+++ b/modules/mail/sogo.nix
@@ -65,11 +65,7 @@ in
           proxy_buffers   8 64k;
           proxy_buffer_size   64k;
         '';
-        forceSSL = true;
-        enableACME = true;
         locations = {
-
-
           "^~/SOGo".extraConfig = lib.mkForce ''
             proxy_pass http://127.0.0.1:20000;
             proxy_redirect http://127.0.0.1:20000 default;

--- a/modules/matrix/default.nix
+++ b/modules/matrix/default.nix
@@ -41,9 +41,6 @@ in
       virtualHosts = {
         # synapse
         "${domainServer}" = {
-          enableACME = true;
-          forceSSL = true;
-
           # homeserver discovery
           locations."= /.well-known/matrix/client".extraConfig = mkWellKnown clientConfig;
           locations."= /.well-known/matrix/server".extraConfig = mkWellKnown serverConfig;
@@ -58,9 +55,6 @@ in
 
         # element
         "${domainClient}" = {
-          enableACME = true;
-          forceSSL = true;
-
           root = pkgs.element-web.override {
             conf = {
               default_server_config = {

--- a/modules/nextcloud.nix
+++ b/modules/nextcloud.nix
@@ -45,12 +45,6 @@ in
       ];
 
     };
-
-    # Enable ACME and force SSL
-    nginx.virtualHosts.${domain} = {
-      enableACME = true;
-      forceSSL = true;
-    };
   };
 
   # ensure that postgres is running *before* running the setup

--- a/modules/nix-serve.nix
+++ b/modules/nix-serve.nix
@@ -10,8 +10,6 @@ in
     port = 5002;
   };
   services.nginx.virtualHosts."${domain}" = {
-    enableACME = true;
-    forceSSL = true;
     locations."/" = {
       proxyPass = "http://127.0.0.1:${toString config.services.nix-serve.port}";
     };

--- a/modules/padlist.nix
+++ b/modules/padlist.nix
@@ -24,8 +24,6 @@ in
 
   services.nginx = {
     virtualHosts.${domain} = {
-      enableACME = true;
-      forceSSL = true;
       root = "/srv/web/padlist";
       locations = {
         "= /" = {

--- a/modules/stream.nix
+++ b/modules/stream.nix
@@ -4,8 +4,6 @@
     nginx = {
       virtualHosts = {
         "stream.${config.networking.domain}" = {
-          enableACME = true;
-          forceSSL = true;
           locations."/" =
             let
               cfg = config.services.owncast;

--- a/modules/vaultwarden.nix
+++ b/modules/vaultwarden.nix
@@ -31,8 +31,6 @@ in
     ensureDatabases = [ "vaultwarden" ];
   };
   services.nginx.virtualHosts."${domain}" = {
-    enableACME = true;
-    forceSSL = true;
     locations."/" = {
       proxyPass = "http://127.0.0.1:${toString config.services.vaultwarden.config.rocketPort}";
     };

--- a/modules/web/ese.nix
+++ b/modules/web/ese.nix
@@ -42,8 +42,6 @@ in
 
   services.nginx = {
     virtualHosts."${cms-domain}" = {
-      enableACME = true;
-      forceSSL = true;
       locations."/" = {
         extraConfig = ''
           if ($request_method = 'OPTIONS') {
@@ -64,8 +62,6 @@ in
       };
     };
     virtualHosts."${domain}" = {
-      enableACME = true;
-      forceSSL = true;
       locations."= /" = {
         return = "301 /2023/";
       };

--- a/modules/web/fsrewsp.nix
+++ b/modules/web/fsrewsp.nix
@@ -37,8 +37,6 @@ in
   services.nginx.enable = true;
   services.nginx = {
     virtualHosts."${domain}" = {
-      addSSL = true;
-      enableACME = true;
       root = "/srv/web/fsrewsp";
       extraConfig = ''
         index index.php index.html;

--- a/modules/web/ftp.nix
+++ b/modules/web/ftp.nix
@@ -5,8 +5,6 @@ in
 {
   services.nginx.additionalModules = [ pkgs.nginxModules.fancyindex ];
   services.nginx.virtualHosts."${domain}" = {
-    enableACME = true;
-    forceSSL = true;
     root = "/srv/ftp";
     extraConfig = ''
       fancyindex on;

--- a/modules/web/ifsrde.nix
+++ b/modules/web/ifsrde.nix
@@ -32,14 +32,9 @@ in
   services.nginx = {
 
     virtualHosts."www.${config.networking.domain}" = {
-      enableACME = true;
-      forceSSL = true;
       locations."/".return = "301 $scheme://ifsr.de$request_uri";
-
     };
     virtualHosts."${config.networking.domain}" = {
-      enableACME = true;
-      forceSSL = true;
       root = "/srv/web/ifsrde";
       extraConfig = ''
         index index.html index.php;

--- a/modules/web/infoscreen.nix
+++ b/modules/web/infoscreen.nix
@@ -6,8 +6,6 @@ in
   services.nginx = {
     enable = true;
     virtualHosts."${domain}" = {
-      addSSL = true;
-      enableACME = true;
       root = "/srv/web/infoscreen/dist";
     };
   };

--- a/modules/web/kpp.nix
+++ b/modules/web/kpp.nix
@@ -7,9 +7,4 @@ in
     enable = true;
     hostName = domain;
   };
-  services.nginx.virtualHosts."${domain}" = {
-    enableACME = true;
-    forceSSL = true;
-  };
-
 }

--- a/modules/web/manual.nix
+++ b/modules/web/manual.nix
@@ -7,10 +7,4 @@ in
     enable = true;
     hostName = domain;
   };
-  services.nginx = {
-    virtualHosts."${domain}" = {
-      addSSL = true;
-      enableACME = true;
-    };
-  };
 }

--- a/modules/web/nightline.nix
+++ b/modules/web/nightline.nix
@@ -34,8 +34,6 @@ in
 
   services.nginx = {
     virtualHosts."${domain}" = {
-      addSSL = true;
-      enableACME = true;
       root = "/srv/web/nightline";
       extraConfig = ''
         index index.php index.html;

--- a/modules/web/sharepic.nix
+++ b/modules/web/sharepic.nix
@@ -33,8 +33,6 @@ in
     enable = true;
 
     virtualHosts."${domain}" = {
-      addSSL = true;
-      enableACME = true;
       root = "/srv/web/sharepic";
       extraConfig = ''
         index index.php index.html;

--- a/modules/web/userdir.nix
+++ b/modules/web/userdir.nix
@@ -61,9 +61,6 @@ in
   };
 
   services.nginx.virtualHosts.${domain} = {
-    enableACME = true;
-    forceSSL = true;
-
     locations."/" = {
       proxyPass = "http://localhost:${toString port}";
       extraConfig = ''

--- a/modules/wiki/ese.nix
+++ b/modules/wiki/ese.nix
@@ -30,8 +30,6 @@ in
   };
   services.nginx = {
     virtualHosts."${domain}" = {
-      addSSL = true;
-      enableACME = true;
       root = "/srv/web/wiki.ese";
       extraConfig = ''
         index index.php;

--- a/modules/wiki/fsr.nix
+++ b/modules/wiki/fsr.nix
@@ -102,8 +102,6 @@ in
     nginx = {
       recommendedProxySettings = true;
       virtualHosts.${domain} = {
-        enableACME = true;
-        forceSSL = true;
         locations."/robots.txt" = {
           extraConfig = ''
             add_header  Content-Type  text/plain;

--- a/modules/wiki/vernetzung.nix
+++ b/modules/wiki/vernetzung.nix
@@ -30,8 +30,6 @@ in
   };
   services.nginx = {
     virtualHosts."${domain}" = {
-      addSSL = true;
-      enableACME = true;
       root = "/srv/web/vernetzung";
       extraConfig = ''
         index index.php;

--- a/modules/zammad.nix
+++ b/modules/zammad.nix
@@ -20,8 +20,6 @@ in
   '';
 
   services.nginx.virtualHosts.${domain} = {
-    enableACME = true;
-    forceSSL = true;
     locations."/" = {
       proxyPass = "http://localhost:${toString config.services.zammad.port}";
     };


### PR DESCRIPTION
This removes a lot of duplicate code and we don't need to worry about it anymore
