### PR TITLE
nginx: enable http3

### DIFF
--- a/modules/core/nginx.nix
+++ b/modules/core/nginx.nix
@@ -7,10 +7,14 @@
         ({ name, ... }: {
           enableACME = true;
           forceSSL = true;
+          # enable http3 for all hosts
+          quic = true;
+          http3 = true;
           # split up nginx access logs per vhost
           extraConfig = ''
             access_log /var/log/nginx/${name}_access.log;
             error_log /var/log/nginx/${name}_error.log;
+            add_header Alt-Svc 'h3=":443"; ma=86400';
           '';
         })
       );
@@ -18,10 +22,12 @@
   };
 
   config = {
-    networking.firewall.allowedTCPPorts = [ 443 80 ];
+    networking.firewall.allowedTCPPorts = [ 80 443 ];
+    networking.firewall.allowedUDPPorts = [ 443 ];
     services.nginx = {
-      additionalModules = [ pkgs.nginxModules.pam ];
       enable = true;
+      package = pkgs.nginxQuic;
+      additionalModules = [ pkgs.nginxModules.pam ];
       recommendedProxySettings = true;
       recommendedGzipSettings = true;
       recommendedOptimisation = true;


### PR DESCRIPTION
This opens the firewall to allow QUIC communication and configures nginx to support http3.
While I'm not sure if it will bring any speed benefits, it doesn't hurt to have.
